### PR TITLE
create tables for simulation when setting up the exchange tables

### DIFF
--- a/db/migrate/20170000000000_create_simulation_tables.rb
+++ b/db/migrate/20170000000000_create_simulation_tables.rb
@@ -11,10 +11,6 @@ class CreateSimulationTables < ActiveRecord::Migration[5.1]
       t.datetime :completed
       t.datetime :startwork
       t.boolean  :updated_issue, default: false
-      t.datetime :created_at, default: -> {'CURRENT_TIMESTAMP'}
-      t.datetime :updated_at, default: -> {'CURRENT_TIMESTAMP'}
-
-      t.timestamps
     end
     add_index :work_queues, :user_uuid
     add_index :work_queues, :issue_uuid
@@ -27,9 +23,6 @@ class CreateSimulationTables < ActiveRecord::Migration[5.1]
       t.string   :comment
       t.datetime :comment_date
       t.datetime :comment_delete
-      t.timestamps
-      t.datetime :created_at, default: -> {'CURRENT_TIMESTAMP'}
-      t.datetime :updated_at, default: -> {'CURRENT_TIMESTAMP'}
     end
     add_index :issue_comments, :issue_uuid
 

--- a/db/migrate/20170000000000_create_simulation_tables.rb
+++ b/db/migrate/20170000000000_create_simulation_tables.rb
@@ -1,0 +1,33 @@
+class CreateSimulationTables < ActiveRecord::Migration[5.1]
+  def change
+
+    create_table :work_queues do |t|
+      t.string   :user_uuid
+      t.string   :issue_uuid
+      t.string   :task
+      t.datetime :added_queue
+      t.integer  :position
+      t.datetime :removed
+      t.datetime :completed
+      t.datetime :startwork
+      t.boolean  :updated_issue, default: false
+
+      t.timestamps
+    end
+    add_index :work_queues, :user_uuid
+    add_index :work_queues, :issue_uuid
+    add_index :work_queues, :completed
+
+    create_table :issue_comments do |t|
+      t.string   :issue_uuid
+      t.string   :user_uuid
+      t.string   :user_name
+      t.string   :comment
+      t.datetime :comment_date
+      t.datetime :comment_delete
+      t.timestamps
+    end
+    add_index :issue_comments, :issue_uuid
+
+  end
+end

--- a/db/migrate/20170000000000_create_simulation_tables.rb
+++ b/db/migrate/20170000000000_create_simulation_tables.rb
@@ -11,6 +11,8 @@ class CreateSimulationTables < ActiveRecord::Migration[5.1]
       t.datetime :completed
       t.datetime :startwork
       t.boolean  :updated_issue, default: false
+      t.datetime :created_at, default: -> {'CURRENT_TIMESTAMP'}
+      t.datetime :updated_at, default: -> {'CURRENT_TIMESTAMP'}
 
       t.timestamps
     end
@@ -26,6 +28,8 @@ class CreateSimulationTables < ActiveRecord::Migration[5.1]
       t.datetime :comment_date
       t.datetime :comment_delete
       t.timestamps
+      t.datetime :created_at, default: -> {'CURRENT_TIMESTAMP'}
+      t.datetime :updated_at, default: -> {'CURRENT_TIMESTAMP'}
     end
     add_index :issue_comments, :issue_uuid
 


### PR DESCRIPTION
`bundle exec rails db:migrate` will create tables for simulation also 

-- not good design, because it should be separate, but it is the quick and dirty way, especially since we have the objects now in the exchange and it causes errors with `BugmHost.reset` if we don't have this.